### PR TITLE
Fix create atoms

### DIFF
--- a/pylammpsmpi/lammps.py
+++ b/pylammpsmpi/lammps.py
@@ -329,7 +329,7 @@ class LammpsLibrary(object):
         """
         self._send(command="reset_box", data=list(args))
 
-    def generate_atoms(self, ids=None, type=None, x=None, v=None, image=False, shrinkexceed=False):
+    def generate_atoms(self, ids=None, type=None, x=None, v=None, image=None, shrinkexceed=False):
         """
         Create atoms on all procs
 
@@ -337,6 +337,7 @@ class LammpsLibrary(object):
         ----------
         ids : list of ints, optional
             ids of N atoms that need to be created
+            if not specified, ids from 1 to N are assigned
 
         type : list of atom types, optional
             type of N atoms, if not specied, all atoms are assigned as type 1
@@ -347,8 +348,8 @@ class LammpsLibrary(object):
         v: list of velocities
             list of the type `[vx, vy, vz]` for N atoms
 
-        image: bool, optional
-            default False
+        image: list of ints, optional
+            if not specified a list of 0s will be used.
 
         shrinkexceed: bool, optional
             default False
@@ -363,6 +364,10 @@ class LammpsLibrary(object):
             natoms = len(x)
             if type is None:
                 type = [1]*natoms
+            if ids is None:
+                ids = list(range(1, natoms+1))
+            if image is None:
+                image = [0]*natoms
 
             funct_args = [natoms, ids, type, x, v, image, shrinkexceed]
             self._send(command="create_atoms", data=funct_args)

--- a/pylammpsmpi/lammps.py
+++ b/pylammpsmpi/lammps.py
@@ -329,9 +329,46 @@ class LammpsLibrary(object):
         """
         self._send(command="reset_box", data=list(args))
 
-    #TODO
-    def create_atoms(self, *args):
-        self._send(command="create_atoms", data=list(args))
+    def generate_atoms(self, ids=None, type=None, x=None, v=None, image=False, shrinkexceed=False):
+        """
+        Create atoms on all procs
+
+        Parameters
+        ----------
+        ids : list of ints, optional
+            ids of N atoms that need to be created
+
+        type : list of atom types, optional
+            type of N atoms, if not specied, all atoms are assigned as type 1
+
+        x: list of positions
+            list of the type `[posx, posy, posz]` for N atoms
+
+        v: list of velocities
+            list of the type `[vx, vy, vz]` for N atoms
+
+        image: bool, optional
+            default False
+
+        shrinkexceed: bool, optional
+            default False
+
+        Returns
+        -------
+        None
+
+        """
+
+        if x is not None:
+            natoms = len(x)
+            if type is None:
+                type = np.ones(natoms)
+
+            funct_args = [natoms, ids, type, x, v, image, shrinkexceed]
+            self._send(command="create_atoms", data=funct_args)
+        else:
+            raise TypeError("Value of x cannot be None")
+
 
     @property
     def has_exceptions(self):

--- a/pylammpsmpi/lammps.py
+++ b/pylammpsmpi/lammps.py
@@ -362,7 +362,7 @@ class LammpsLibrary(object):
         if x is not None:
             natoms = len(x)
             if type is None:
-                type = np.ones(natoms)
+                type = [1]*natoms
 
             funct_args = [natoms, ids, type, x, v, image, shrinkexceed]
             self._send(command="create_atoms", data=funct_args)

--- a/pylammpsmpi/mpi/lmpmpi.py
+++ b/pylammpsmpi/mpi/lmpmpi.py
@@ -247,7 +247,27 @@ def gather_atoms_subset(funct_args):
 
 
 def create_atoms(funct_args):
-    job.create_atoms(*funct_args)
+    #we have to process the input items
+    #args are natoms, ids, type, x, v, image, shrinkexceed
+    natoms = funct_args[0]
+    ids = funct_args[1]
+    type = funct_args[2]
+    x = funct_args[3]
+    v = funct_args[4]
+    image = funct_args[5]
+    shrinkexceed = funct_args[6]
+
+    id_lmp = (c_int * natoms)()
+    id_lmp[:] = ids
+
+    type_lmp = (c_int * natoms)()
+    type_lmp[:] = type
+
+    image_lmp = (c_int * natoms)()
+    image_lmp[:] = image
+
+    args = [natoms, id_lmp, type_lmp, x, v, image_lmp, shrinkexceed]
+    job.create_atoms(*args)
 
 
 def has_exceptions(funct_args):


### PR DESCRIPTION
This renames the inbuit `create_atoms` to `generate_atoms`, so that `lmp.create_atoms` can be used. See #27 . The function `create_atoms` from the lammps library (https://github.com/lammps/lammps/blob/master/python/lammps.py#L670) does not seem to work properly due to some problem with `shrinkexceed`