### PR TITLE
Hide internal classes in utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install pylammpsmpi
 
 
 ```python
-from pylammpsmpi.lammps import LammpsLibrary
+from pylammpsmpi import LammpsLibrary
 ```
 
 Set up a job which runs on 2 cores

--- a/pylammpsmpi/lammps_wrapper.py
+++ b/pylammpsmpi/lammps_wrapper.py
@@ -1,5 +1,20 @@
-from pylammpsmpi.commands import command_list, thermo_list, func_list, prop_list
-from pylammpsmpi.lammps import LammpsBase
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from pylammpsmpi.utils.commands import command_list, thermo_list, func_list, prop_list
+from pylammpsmpi.utils.lammps import LammpsBase
+
+__author__ = "Sarath Menon, Jan Janssen"
+__copyright__ = (
+    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Jan Janssen"
+__email__ = "janssen@mpie.de"
+__status__ = "production"
+__date__ = "Feb 28, 2020"
 
 
 class LammpsLibrary:

--- a/pylammpsmpi/utils/commands.py
+++ b/pylammpsmpi/utils/commands.py
@@ -1,3 +1,19 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+__author__ = "Sarath Menon, Jan Janssen"
+__copyright__ = (
+    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Jan Janssen"
+__email__ = "janssen@mpie.de"
+__status__ = "production"
+__date__ = "Feb 28, 2020"
+
+
 func_list = [
     'file', 'extract_global', 'extract_box', 'extract_atom',
     'extract_fix', 'extract_variable', 'get_natoms', 'set_variable',

--- a/pylammpsmpi/utils/lammps.py
+++ b/pylammpsmpi/utils/lammps.py
@@ -27,7 +27,7 @@ class LammpsBase:
 
     def start_process(self):
         executable = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "mpi", "lmpmpi.py"
+            os.path.dirname(os.path.abspath(__file__)), "../mpi", "lmpmpi.py"
         )
         self._process = subprocess.Popen(
             ["mpiexec", "--oversubscribe", "-n", str(self.cores), "python", executable],


### PR DESCRIPTION
To simplify embedding the class in other projects we should highlight that the user should only load the lammps library wrapper.