### PR TITLE
Use `oversubscribe` option only for Dask clusters

### DIFF
--- a/pylammpsmpi/lammps_wrapper.py
+++ b/pylammpsmpi/lammps_wrapper.py
@@ -33,6 +33,7 @@ class LammpsLibrary:
                 LammpsBase,
                 cores=self.cores,
                 working_directory=self.working_directory,
+                local=False,
                 actor=True,
             )
             self.lmp = fut.result()

--- a/pylammpsmpi/utils/lammps.py
+++ b/pylammpsmpi/utils/lammps.py
@@ -33,7 +33,14 @@ class LammpsBase:
         if self.local:
             command_array = ["mpiexec", "-n", str(self.cores), "python", executable]
         else:
-            command_array = ["mpiexec", "--oversubscribe", "-n", str(self.cores), "python", executable] 
+            command_array = [
+                "mpiexec",
+                "--oversubscribe",
+                "-n",
+                str(self.cores),
+                "python",
+                executable,
+            ]
         self._process = subprocess.Popen(
             command_array,
             stdout=subprocess.PIPE,

--- a/pylammpsmpi/utils/lammps.py
+++ b/pylammpsmpi/utils/lammps.py
@@ -20,17 +20,22 @@ __date__ = "Feb 28, 2020"
 
 
 class LammpsBase:
-    def __init__(self, cores=8, working_directory="."):
+    def __init__(self, cores=8, working_directory=".", local=True):
         self.cores = cores
         self.working_directory = working_directory
         self._process = None
+        self.local = local
 
     def start_process(self):
         executable = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "../mpi", "lmpmpi.py"
         )
+        if self.local:
+            command_array = ["mpiexec", "-n", str(self.cores), "python", executable]
+        else:
+            command_array = ["mpiexec", "--oversubscribe", "-n", str(self.cores), "python", executable] 
         self._process = subprocess.Popen(
-            ["mpiexec", "--oversubscribe", "-n", str(self.cores), "python", executable],
+            command_array,
             stdout=subprocess.PIPE,
             stderr=None,
             stdin=subprocess.PIPE,


### PR DESCRIPTION
The MPI run command uses `oversubscribe` option which is only useful if Dask clusters are used. However, this option fails with mpich. I added a small workaround, which only uses this option if a Dask cluster is used.

This fix could be the solution for [this](https://github.com/pyiron/pyiron_atomistics/issues/484) and [this](https://github.com/pyiron/pyiron_atomistics/issues/377).

@niklassiemer Could you please help with the tag for black formatting?
