### PR TITLE
Allow custom cmdargs

### DIFF
--- a/pylammpsmpi/lammps_wrapper.py
+++ b/pylammpsmpi/lammps_wrapper.py
@@ -22,7 +22,7 @@ class LammpsLibrary:
     Top level class which manages the lammps library provided by LammpsBase
     """
 
-    def __init__(self, cores=1, working_directory=".", client=None, mode="local"):
+    def __init__(self, cores=1, working_directory=".", client=None, mode="local", cmdargs=None):
         self.cores = cores
         self.working_directory = working_directory
         self.client = client
@@ -42,7 +42,7 @@ class LammpsLibrary:
 
         elif self.mode == "local":
             self.lmp = LammpsBase(
-                cores=self.cores, working_directory=self.working_directory
+                cores=self.cores, working_directory=self.working_directory, cmdargs=cmdargs
             )
             self.lmp.start_process()
 

--- a/pylammpsmpi/mpi/lmpmpi.py
+++ b/pylammpsmpi/mpi/lmpmpi.py
@@ -44,7 +44,7 @@ atom_properties = {
 # Lammps executable
 args = ["-screen", "none"]
 if len(sys.argv) > 1:
-    args.extend(sys.argv[0:])
+    args.extend(sys.argv[1:])
 job = lammps(cmdargs=args)
 
 

--- a/pylammpsmpi/mpi/lmpmpi.py
+++ b/pylammpsmpi/mpi/lmpmpi.py
@@ -42,7 +42,10 @@ atom_properties = {
 }
 
 # Lammps executable
-job = lammps(cmdargs=["-screen", "none"])
+args = ["-screen", "none"]
+if len(sys.argv) > 1:
+    args.extend(sys.argv[0:])
+job = lammps(cmdargs=args)
 
 
 def extract_compute(funct_args):

--- a/pylammpsmpi/utils/lammps.py
+++ b/pylammpsmpi/utils/lammps.py
@@ -30,22 +30,16 @@ class LammpsBase:
         executable = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "../mpi", "lmpmpi.py"
         )
-        if self._cmdargs is None:
-            self._process = subprocess.Popen(
-                ["mpiexec", "--oversubscribe", "-n", str(self.cores), "python", executable],
-                stdout=subprocess.PIPE,
-                stderr=None,
-                stdin=subprocess.PIPE,
-                cwd=self.working_directory,
-            )
-        else:
-            self._process = subprocess.Popen(
-                ["mpiexec", "--oversubscribe", "-n", str(self.cores), "python", executable] + self._cmdargs,
-                stdout=subprocess.PIPE,
-                stderr=None,
-                stdin=subprocess.PIPE,
-                cwd=self.working_directory,
-            )
+        cmds = ["mpiexec", "--oversubscribe", "-n", str(self.cores), "python", executable]
+        if self._cmdargs is not None:
+            cmds.extend(self._cmdargs)
+        self._process = subprocess.Popen(
+            cmds,
+            stdout=subprocess.PIPE,
+            stderr=None,
+            stdin=subprocess.PIPE,
+            cwd=self.working_directory,
+        )
 
     def _send(self, command, data=None):
         """

--- a/pylammpsmpi/utils/lammps.py
+++ b/pylammpsmpi/utils/lammps.py
@@ -20,22 +20,32 @@ __date__ = "Feb 28, 2020"
 
 
 class LammpsBase:
-    def __init__(self, cores=8, working_directory="."):
+    def __init__(self, cores=8, working_directory=".", cmdargs=None):
         self.cores = cores
         self.working_directory = working_directory
         self._process = None
+        self._cmdargs = cmdargs
 
     def start_process(self):
         executable = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "../mpi", "lmpmpi.py"
         )
-        self._process = subprocess.Popen(
-            ["mpiexec", "--oversubscribe", "-n", str(self.cores), "python", executable],
-            stdout=subprocess.PIPE,
-            stderr=None,
-            stdin=subprocess.PIPE,
-            cwd=self.working_directory,
-        )
+        if self._cmdargs is None:
+            self._process = subprocess.Popen(
+                ["mpiexec", "--oversubscribe", "-n", str(self.cores), "python", executable],
+                stdout=subprocess.PIPE,
+                stderr=None,
+                stdin=subprocess.PIPE,
+                cwd=self.working_directory,
+            )
+        else:
+            self._process = subprocess.Popen(
+                ["mpiexec", "--oversubscribe", "-n", str(self.cores), "python", executable] + self._cmdargs,
+                stdout=subprocess.PIPE,
+                stderr=None,
+                stdin=subprocess.PIPE,
+                cwd=self.working_directory,
+            )
 
     def _send(self, command, data=None):
         """

--- a/tests/test_pylammpsmpi_local.py
+++ b/tests/test_pylammpsmpi_local.py
@@ -81,5 +81,10 @@ class TestLocalLammpsLibrary(unittest.TestCase):
         self.lmp.file(os.path.join(self.execution_path, "in.simple"))
 
 
+    def test_cmdarg_options(self):
+        self.lmp2 = LammpsLibrary(cores=2, mode='local', cmdargs=["-cite", "citations.txt"])
+        self.lmp2.file(os.path.join(self.execution_path, "in.simple"))
+        assert os.path.isfile(os.path.join(self.execution_path, "citations.txt"))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Allow to add custom args to lammps initialization. Allows to use accelarator packages (f.e. -sf intel), gpus, etc.