### PR TITLE
Remove mode argument

### DIFF
--- a/notebooks/lammps_local.ipynb
+++ b/notebooks/lammps_local.ipynb
@@ -34,11 +34,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "lmp = LammpsLibrary(cores=2, mode=\"local\")"
+    "lmp = LammpsLibrary(cores=2)"
    ]
   },
   {

--- a/pylammpsmpi/wrapper/extended.py
+++ b/pylammpsmpi/wrapper/extended.py
@@ -245,7 +245,6 @@ class LammpsLibrary:
         oversubscribe (bool): Whether to oversubscribe CPU cores (default: False)
         working_directory (str): Path to the working directory (default: ".")
         client: Client object for distributed computing (default: None)
-        mode (str): Mode of operation (default: "local")
         cmdargs: Additional command line arguments for Lammps (default: None)
     """
 
@@ -255,14 +254,12 @@ class LammpsLibrary:
         oversubscribe: bool = False,
         working_directory: str = ".",
         client: Any = None,
-        mode: str = "local",
         cmdargs: Optional[list[str]] = None,
     ) -> None:
         self.cores = cores
         self.working_directory = working_directory
         self.oversubscribe = oversubscribe
         self.client = client
-        self.mode = mode
         self.lmp = LammpsConcurrent(
             cores=self.cores,
             oversubscribe=self.oversubscribe,

--- a/tests/test_ase_interface.py
+++ b/tests/test_ase_interface.py
@@ -25,7 +25,7 @@ class TestLammpsASELibrary(unittest.TestCase):
             comm=None,
             logger=logging.getLogger("TestStaticLogger"),
             log_file=None,
-            library=LammpsLibrary(cores=2, mode="local"),
+            library=LammpsLibrary(cores=2),
             disable_log_file=True,
         )
         structure = bulk("Al", cubic=True).repeat([2, 2, 2])
@@ -84,7 +84,7 @@ class TestLammpsASELibrary(unittest.TestCase):
             comm=None,
             logger=logging.getLogger("TestStaticLogger"),
             log_file=None,
-            library=LammpsLibrary(cores=2, mode="local"),
+            library=LammpsLibrary(cores=2),
             disable_log_file=True,
         )
         structure = bulk("Al", cubic=True)
@@ -128,7 +128,7 @@ class TestLammpsASELibrary(unittest.TestCase):
             comm=None,
             logger=logging.getLogger("TestStaticLogger"),
             log_file=None,
-            library=LammpsLibrary(cores=2, mode="local"),
+            library=LammpsLibrary(cores=2),
             disable_log_file=True,
         )
         structure = bulk("Al").repeat([2, 2, 2])
@@ -417,7 +417,7 @@ class TestBinary(unittest.TestCase):
                 comm=None,
                 logger=logging.getLogger("TestStaticLogger"),
                 log_file=None,
-                library=LammpsLibrary(cores=2, mode="local"),
+                library=LammpsLibrary(cores=2),
                 disable_log_file=True,
             )
             lmp.interactive_structure_setter(
@@ -442,7 +442,7 @@ class TestBinary(unittest.TestCase):
             comm=None,
             logger=logging.getLogger("TestStaticLogger"),
             log_file=None,
-            library=LammpsLibrary(cores=2, mode="local"),
+            library=LammpsLibrary(cores=2),
             disable_log_file=True,
         )
         for structure in self.structure_lst:
@@ -468,7 +468,7 @@ class TestBinary(unittest.TestCase):
             comm=None,
             logger=logging.getLogger("TestStaticLogger"),
             log_file=None,
-            library=LammpsLibrary(cores=2, mode="local"),
+            library=LammpsLibrary(cores=2),
             disable_log_file=True,
         )
         for structure in self.structure_lst[::-1]:

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -47,7 +47,7 @@ class TestException(TestCase):
         with open("in.error", "w") as f:
             f.writelines(lmp_str)
         with self.assertRaises(Exception):
-            lmp = LammpsLibrary(cores=2, mode="local")
+            lmp = LammpsLibrary(cores=2)
             lmp.file("in.error")
 
     def tearDown(self):

--- a/tests/test_pylammpsmpi_local.py
+++ b/tests/test_pylammpsmpi_local.py
@@ -17,7 +17,7 @@ class TestLocalLammpsLibrary(unittest.TestCase):
         cls.citation_file = os.path.join(cls.execution_path, "citations.txt")
         cls.lammps_file = os.path.join(cls.execution_path, "in.simple")
         cls.lmp = LammpsLibrary(
-            cores=2, mode="local", cmdargs=["-cite", cls.citation_file]
+            cores=2, cmdargs=["-cite", cls.citation_file]
         )
         cls.lmp.file(cls.lammps_file)
 

--- a/tests/test_pylammpsmpi_local.py
+++ b/tests/test_pylammpsmpi_local.py
@@ -16,9 +16,7 @@ class TestLocalLammpsLibrary(unittest.TestCase):
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))
         cls.citation_file = os.path.join(cls.execution_path, "citations.txt")
         cls.lammps_file = os.path.join(cls.execution_path, "in.simple")
-        cls.lmp = LammpsLibrary(
-            cores=2, cmdargs=["-cite", cls.citation_file]
-        )
+        cls.lmp = LammpsLibrary(cores=2, cmdargs=["-cite", cls.citation_file])
         cls.lmp.file(cls.lammps_file)
 
     @classmethod


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the initialization of LammpsLibrary by removing the need to specify the mode parameter.
* **Tests**
  * Updated all test cases to instantiate LammpsLibrary without the mode argument, ensuring compatibility with the new initialization method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->