### PR TITLE
This commit adds new unit tests for three previously untested functio…

### DIFF
--- a/pylammpsmpi/_version.py
+++ b/pylammpsmpi/_version.py
@@ -5,8 +5,7 @@ __all__ = ["__version__", "__version_tuple__", "version", "version_tuple"]
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Tuple
-    from typing import Union
+    from typing import Tuple, Union
 
     VERSION_TUPLE = Tuple[Union[int, str], ...]
 else:
@@ -17,5 +16,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '0.1.dev2+g38e9ba3'
-__version_tuple__ = version_tuple = (0, 1, 'dev2', 'g38e9ba3')
+__version__ = version = "0.0.1"
+__version_tuple__ = version_tuple = (0, 0, 1)

--- a/pylammpsmpi/_version.py
+++ b/pylammpsmpi/_version.py
@@ -5,7 +5,8 @@ __all__ = ["__version__", "__version_tuple__", "version", "version_tuple"]
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Tuple, Union
+    from typing import Tuple
+    from typing import Union
 
     VERSION_TUPLE = Tuple[Union[int, str], ...]
 else:
@@ -16,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = "0.0.1"
-__version_tuple__ = version_tuple = (0, 0, 1)
+__version__ = version = '0.1.dev2+g38e9ba3'
+__version_tuple__ = version_tuple = (0, 1, 'dev2', 'g38e9ba3')


### PR DESCRIPTION
…ns in the `pylammpsmpi/wrapper/ase.py` file. The new tests cover the following functions:

- `get_species_indices_dict`
- `get_lammps_indicies_from_ase_indices`
- `get_fixed_atom_boolean_vector`

These tests improve the test coverage of the `pylammpsmpi` package.

It is important to note that the test environment was not working correctly, which prevented the execution of any tests. All attempts to run the test suite resulted in a timeout. Therefore, the new tests have not been verified to pass, and the test coverage has not been confirmed to be 100%. The new tests were written based on a manual inspection of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ASE integration utilities to: derive per-species index mappings, translate selected atomic indices to per-atom indices for simulations, and generate boolean masks for fixed atoms under common constraints. Enhances structure preparation and constraint handling workflows.

- Tests
  - Introduced comprehensive tests validating the new utilities across single- and multi-element structures and combined constraint scenarios, improving reliability and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->