### PR TITLE
Fix  issue with second lmp instance

### DIFF
--- a/src/pylammpsmpi/wrapper/concurrent.py
+++ b/src/pylammpsmpi/wrapper/concurrent.py
@@ -38,6 +38,7 @@ def init_function():
 
         def shutdown(self):
             if self._job is not None:
+                self._job.finalize()
                 self._job.close()
                 self._job = None
 

--- a/src/pylammpsmpi/wrapper/extended.py
+++ b/src/pylammpsmpi/wrapper/extended.py
@@ -319,7 +319,6 @@ class LammpsLibrary:
         """
         Close the Lammps simulation
         """
-        self.lmp.finalize()
         self.lmp.close()
 
     def __dir__(self) -> list[str]:

--- a/src/pylammpsmpi/wrapper/extended.py
+++ b/src/pylammpsmpi/wrapper/extended.py
@@ -319,6 +319,7 @@ class LammpsLibrary:
         """
         Close the Lammps simulation
         """
+        self.lmp.finalize()
         self.lmp.close()
 
     def __dir__(self) -> list[str]:


### PR DESCRIPTION
Properly close the lammps instance to allow multi step processes such as calphy to run on GPUs. Without properly closing the process hangs without throwing an error, so in the case of calphy it stopped silently after the averaging routine.
Complementary to https://github.com/ICAMS/calphy/pull/205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown sequence to ensure proper resource cleanup and finalization of active jobs before terminating.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->