### PR TITLE
Update LAMMPS to 2025.07.22

### DIFF
--- a/.ci_support/environment-mpich.yml
+++ b/.ci_support/environment-mpich.yml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 dependencies:
 - coverage
-- lammps =2024.08.29=*_mpi_mpich_*
+- lammps =2025.07.22=*_mpi_mpich_*
 - mpich =4.3.2
 - numpy =2.4.6
 - mpi4py =4.1.2

--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -4,9 +4,9 @@ dependencies:
 - lammps =2025.07.22=*_mpi_openmpi_*
 - openmpi
 - numpy =2.4.6
-- mpi4py =3.1.4
+- mpi4py =4.1.2
 - executorlib =1.9.0
 - ase =3.23.0
-- scipy =1.9.3
+- scipy =1.15.0
 - hatchling
 - hatch-vcs

--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -1,9 +1,9 @@
 channels:
 - conda-forge
 dependencies:
-- lammps =2022.06.23
+- lammps =2025.07.22=*_mpi_openmpi_*
 - openmpi
-- numpy =1.23.5
+- numpy =2.4.6
 - mpi4py =3.1.4
 - executorlib =1.9.0
 - ase =3.23.0

--- a/.ci_support/environment-openmpi.yml
+++ b/.ci_support/environment-openmpi.yml
@@ -2,8 +2,8 @@ channels:
 - conda-forge
 dependencies:
 - coverage
-- lammps =2024.08.29=*_mpi_openmpi_*
-- openmpi =5.0.8
+- lammps =2025.07.22=*_mpi_openmpi_*
+- openmpi =5.0.10
 - numpy =2.4.6
 - mpi4py =4.1.2
 - executorlib =1.9.3

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -199,7 +199,7 @@ jobs:
       run: echo -e "channels:\n  - conda-forge\n" > .condarc
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         miniforge-version: latest
         condarc-file: .condarc
         environment-file: .ci_support/environment-old.yml

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - hatchling =1.30.1
 - hatch-vcs =0.5.0
 - numpy =2.4.6
-- lammps =2024.08.29=*_mpi_openmpi_*
+- lammps =2025.07.22=*_mpi_openmpi_*
 - mpi4py =4.1.2
 - executorlib =1.9.3
 - ase =3.28.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,13 @@ authors = [
 readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["pyiron"]
-requires-python = ">=3.9, <3.14"
+requires-python = ">=3.11, <3.14"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Topic :: Scientific/Engineering :: Physics",
     "License :: OSI Approved :: BSD License",
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/src/pylammpsmpi/wrapper/ase.py
+++ b/src/pylammpsmpi/wrapper/ase.py
@@ -308,8 +308,8 @@ class LammpsASELibrary:
         if self._cores == 1:
             self._interactive_library.create_atoms(
                 n=len(structure),
-                id=None,
-                type=elem_all,
+                atomid=None,
+                atype=elem_all,
                 x=positions,
                 v=velocities,
                 image=None,
@@ -318,8 +318,8 @@ class LammpsASELibrary:
         else:
             self._interactive_library.create_atoms(
                 n=len(structure),
-                id=range(1, len(structure) + 1),
-                type=elem_all,
+                atomid=range(1, len(structure) + 1),
+                atype=elem_all,
                 x=positions,
                 v=velocities,
                 image=None,

--- a/src/pylammpsmpi/wrapper/ase.py
+++ b/src/pylammpsmpi/wrapper/ase.py
@@ -2,7 +2,7 @@ import importlib
 import os
 import warnings
 from ctypes import c_double, c_int
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import numpy as np
 from ase.atoms import Atoms
@@ -31,15 +31,15 @@ class LammpsASELibrary:
 
     def __init__(
         self,
-        working_directory: Optional[str] = None,
-        hostname_localhost: Optional[bool] = None,
+        working_directory: str | None = None,
+        hostname_localhost: bool | None = None,
         cores: int = 1,
-        comm: Optional[object] = None,
-        logger: Optional[object] = None,
-        log_file: Optional[str] = None,
+        comm: object | None = None,
+        logger: object | None = None,
+        log_file: str | None = None,
         library: Any = None,
         disable_log_file: bool = True,
-        executor: Optional[BaseExecutor] = None,
+        executor: BaseExecutor | None = None,
     ):
         self._logger: Any = logger
         self._prism: Any = None

--- a/src/pylammpsmpi/wrapper/base.py
+++ b/src/pylammpsmpi/wrapper/base.py
@@ -270,7 +270,13 @@ class LammpsBase(LammpsConcurrent):
         _ = (
             super()
             .create_atoms(
-                n=n, atomid=atomid, atype=atype, x=x, v=v, image=image, shrinkexceed=shrinkexceed
+                n=n,
+                atomid=atomid,
+                atype=atype,
+                x=x,
+                v=v,
+                image=image,
+                shrinkexceed=shrinkexceed,
             )
             .result()
         )

--- a/src/pylammpsmpi/wrapper/base.py
+++ b/src/pylammpsmpi/wrapper/base.py
@@ -231,8 +231,8 @@ class LammpsBase(LammpsConcurrent):
     def create_atoms(  # type: ignore[override]
         self,
         n: int,
-        id: list[int],
-        type: list[int],
+        atomid: list[int],
+        atype: list[int],
         x: list[float],
         v: Optional[list[float]] = None,
         image: Optional[list[int]] = None,
@@ -245,11 +245,11 @@ class LammpsBase(LammpsConcurrent):
         n : int
             number of atoms
 
-        id : list of ints, optional
+        atomid : list of ints, optional
             ids of N atoms that need to be created
             if not specified, ids from 1 to N are assigned
 
-        type : list of atom types, optional
+        atype : list of atom types, optional
             type of N atoms, if not specified, all atoms are assigned as type 1
 
         x: list of positions
@@ -270,7 +270,7 @@ class LammpsBase(LammpsConcurrent):
         _ = (
             super()
             .create_atoms(
-                n=n, id=id, type=type, x=x, v=v, image=image, shrinkexceed=shrinkexceed
+                n=n, atomid=atomid, atype=atype, x=x, v=v, image=image, shrinkexceed=shrinkexceed
             )
             .result()
         )

--- a/src/pylammpsmpi/wrapper/base.py
+++ b/src/pylammpsmpi/wrapper/base.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 from concurrent.futures import Future
-from typing import Any, Optional, Union
+from typing import Any
 
 from pylammpsmpi.wrapper.concurrent import LammpsConcurrent
 
@@ -51,7 +51,7 @@ class LammpsBase(LammpsConcurrent):
         _ = super().file(inputfile=inputfile).result()
 
     # TODO
-    def extract_setting(self, *args) -> Union[int, float, str]:
+    def extract_setting(self, *args) -> int | float | str:
         """
         Extract a setting value
 
@@ -65,7 +65,7 @@ class LammpsBase(LammpsConcurrent):
         """
         return get_result(future=super().extract_setting(*args), cores=self.cores)
 
-    def extract_global(self, name: str) -> Union[int, float, str]:  # type: ignore[override]
+    def extract_global(self, name: str) -> int | float | str:  # type: ignore[override]
         """
         Extract value of global simulation parameters
 
@@ -79,7 +79,7 @@ class LammpsBase(LammpsConcurrent):
         """
         return get_result(future=super().extract_global(name=name), cores=self.cores)
 
-    def extract_box(self) -> list[Union[float, list[float], list[int]]]:  # type: ignore[override]
+    def extract_box(self) -> list[float | list[float] | list[int]]:  # type: ignore[override]
         """
         Get the simulation box
 
@@ -94,7 +94,7 @@ class LammpsBase(LammpsConcurrent):
         """
         return get_result(future=super().extract_box(), cores=self.cores)
 
-    def extract_atom(self, name: str) -> Union[list[int], list[float]]:  # type: ignore[override]
+    def extract_atom(self, name: str) -> list[int] | list[float]:  # type: ignore[override]
         """
         Extract a property of the atoms
 
@@ -109,7 +109,7 @@ class LammpsBase(LammpsConcurrent):
         """
         return get_result(future=super().extract_atom(name=name), cores=self.cores)
 
-    def extract_fix(self, *args) -> Union[int, float, list[Union[int, float]]]:  # type: ignore[override]
+    def extract_fix(self, *args) -> int | float | list[int | float]:  # type: ignore[override]
         """
         Extract a fix value
 
@@ -123,7 +123,7 @@ class LammpsBase(LammpsConcurrent):
         """
         return get_result(future=super().extract_fix(*args), cores=self.cores)
 
-    def extract_variable(self, *args) -> Union[int, float, list[Union[int, float]]]:  # type: ignore[override]
+    def extract_variable(self, *args) -> int | float | list[int | float]:  # type: ignore[override]
         """
         Extract the value of a variable
 
@@ -187,11 +187,11 @@ class LammpsBase(LammpsConcurrent):
 
     def generate_atoms(  # type: ignore[override]
         self,
-        ids: Optional[list[int]] = None,
-        type: Optional[list[int]] = None,
-        x: Optional[list[float]] = None,
-        v: Optional[list[float]] = None,
-        image: Optional[list[int]] = None,
+        ids: list[int] | None = None,
+        type: list[int] | None = None,
+        x: list[float] | None = None,
+        v: list[float] | None = None,
+        image: list[int] | None = None,
         shrinkexceed: bool = False,
     ) -> None:
         """
@@ -234,8 +234,8 @@ class LammpsBase(LammpsConcurrent):
         atomid: list[int],
         atype: list[int],
         x: list[float],
-        v: Optional[list[float]] = None,
-        image: Optional[list[int]] = None,
+        v: list[float] | None = None,
+        image: list[int] | None = None,
         shrinkexceed: bool = False,
     ) -> None:
         """

--- a/src/pylammpsmpi/wrapper/concurrent.py
+++ b/src/pylammpsmpi/wrapper/concurrent.py
@@ -319,11 +319,11 @@ class LammpsConcurrent:
         else:
             raise TypeError("Value of x cannot be None")
         return self.create_atoms(
-            n=n, id=ids, type=type, x=x, v=v, image=image, shrinkexceed=shrinkexceed
+            n=n, atomid=ids, atype=type, x=x, v=v, image=image, shrinkexceed=shrinkexceed
         )
 
     def create_atoms(
-        self, n, id, type, x, v=None, image=None, shrinkexceed=False
+        self, n, atomid, atype, x, v=None, image=None, shrinkexceed=False
     ) -> Future:
         """
         Create atoms on all processors.
@@ -332,9 +332,9 @@ class LammpsConcurrent:
         ----------
         n : int
             Number of atoms.
-        id : list of ints, optional
+        atomid : list of ints, optional
             IDs of N atoms that need to be created.
-        type : list of atom types, optional
+        atype : list of atom types, optional
             Type of N atoms.
         x : list of positions
             List of positions for N atoms.
@@ -350,7 +350,7 @@ class LammpsConcurrent:
         None
         """
         if x is not None:
-            funct_args = [n, id, type, x, v, image, shrinkexceed]
+            funct_args = [n, atomid, atype, x, v, image, shrinkexceed]
             return self._send_and_receive_dict(command="create_atoms", data=funct_args)
         else:
             raise TypeError("Value of x cannot be None")

--- a/src/pylammpsmpi/wrapper/concurrent.py
+++ b/src/pylammpsmpi/wrapper/concurrent.py
@@ -319,7 +319,13 @@ class LammpsConcurrent:
         else:
             raise TypeError("Value of x cannot be None")
         return self.create_atoms(
-            n=n, atomid=ids, atype=type, x=x, v=v, image=image, shrinkexceed=shrinkexceed
+            n=n,
+            atomid=ids,
+            atype=type,
+            x=x,
+            v=v,
+            image=image,
+            shrinkexceed=shrinkexceed,
         )
 
     def create_atoms(

--- a/src/pylammpsmpi/wrapper/concurrent.py
+++ b/src/pylammpsmpi/wrapper/concurrent.py
@@ -4,7 +4,7 @@
 import contextlib
 import os
 from concurrent.futures import Future
-from typing import Any, Optional
+from typing import Any
 
 from executorlib import BaseExecutor, SingleNodeExecutor
 
@@ -73,9 +73,9 @@ class LammpsConcurrent:
         cores: int = 8,
         oversubscribe: bool = False,
         working_directory: str = ".",
-        hostname_localhost: Optional[bool] = None,
-        cmdargs: Optional[list[Any]] = None,
-        executor: Optional[BaseExecutor] = None,
+        hostname_localhost: bool | None = None,
+        cmdargs: list[Any] | None = None,
+        executor: BaseExecutor | None = None,
     ):
         """
         Initialize the LammpsConcurrent object.

--- a/src/pylammpsmpi/wrapper/extended.py
+++ b/src/pylammpsmpi/wrapper/extended.py
@@ -1,7 +1,7 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from typing import Any, Optional
+from typing import Any
 
 from executorlib import BaseExecutor
 
@@ -257,10 +257,10 @@ class LammpsLibrary:
         cores: int = 1,
         oversubscribe: bool = False,
         working_directory: str = ".",
-        hostname_localhost: Optional[bool] = None,
+        hostname_localhost: bool | None = None,
         client: Any = None,
-        cmdargs: Optional[list[str]] = None,
-        executor: Optional[BaseExecutor] = None,
+        cmdargs: list[str] | None = None,
+        executor: BaseExecutor | None = None,
     ) -> None:
         self.cores = cores
         self.working_directory = working_directory

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -115,7 +115,7 @@ class TestLammpsBase(unittest.TestCase):
     def test_version(self):
         self.assertTrue(
             self.lmp.version
-            in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829]
+            in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829, 20250722]
         )
 
     def test_extract_global(self):

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -99,7 +99,7 @@ class TestLammpsConcurrent(unittest.TestCase):
     def test_version(self):
         self.assertTrue(
             self.lmp.version.result()
-            in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829]
+            in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829, 20250722]
         )
 
     def test_extract_global(self):

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -132,7 +132,7 @@ class TestLammpsConcurrent(unittest.TestCase):
 
     def test_create_atoms_typeerror(self):
         with self.assertRaises(TypeError):
-            self.lmp.create_atoms(n=1, id=[1], type=[1], x=None)
+            self.lmp.create_atoms(n=1, atomid=[1], atype=[1], x=None)
 
 
 if __name__ == "__main__":

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -62,6 +62,6 @@ class TestLammpsInterface(unittest.TestCase):
             call_function_lmp(
                 lmp=lmp, input_dict={"command": "get_version", "args": []}
             )
-            in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829]
+            in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829, 20250722]
         )
         self.assertTrue(shutdown_lmp(lmp=lmp))

--- a/tests/test_mpi_backend.py
+++ b/tests/test_mpi_backend.py
@@ -86,7 +86,7 @@ class TestMpiBackend(unittest.TestCase):
     def test_version(self):
         self.assertTrue(
             select_cmd("get_version")(job=self.lmp, funct_args=[])
-            in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829]
+            in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829, 20250722]
         )
 
     def test_extract_global(self):

--- a/tests/test_mpi_backend_extended.py
+++ b/tests/test_mpi_backend_extended.py
@@ -72,10 +72,10 @@ class TestMpiBackendExtended(unittest.TestCase):
         self.assertEqual(ret, 1)
 
     def test_extract_variable_error(self):
-        v = select_cmd("extract_variable")(
-            job=self.lmp, funct_args=["var_not_exist", "all", 0]
-        )
-        self.assertIsNone(v)
+        with self.assertRaises(Exception):
+            select_cmd("extract_variable")(
+                job=self.lmp, funct_args=["var_not_exist", "all", 0]
+            )
 
     def test_gather_atoms_concat(self):
         f = select_cmd("gather_atoms_concat")(job=self.lmp, funct_args=["f"])

--- a/tests/test_pylammpsmpi_local.py
+++ b/tests/test_pylammpsmpi_local.py
@@ -156,7 +156,15 @@ class TestExecutorLammpsLibrary(unittest.TestCase):
             lmp.file(lammps_file)
             self.assertTrue(
                 lmp.version
-                in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829, 20250722]
+                in [
+                    20220623,
+                    20230802,
+                    20231121,
+                    20240207,
+                    20240627,
+                    20240829,
+                    20250722,
+                ]
             )
             lmp.close()
 

--- a/tests/test_pylammpsmpi_local.py
+++ b/tests/test_pylammpsmpi_local.py
@@ -29,7 +29,7 @@ class TestLocalLammpsLibrary(unittest.TestCase):
     def test_version(self):
         self.assertTrue(
             self.lmp.version
-            in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829]
+            in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829, 20250722]
         )
 
     def test_extract_atom(self):
@@ -156,7 +156,7 @@ class TestExecutorLammpsLibrary(unittest.TestCase):
             lmp.file(lammps_file)
             self.assertTrue(
                 lmp.version
-                in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829]
+                in [20220623, 20230802, 20231121, 20240207, 20240627, 20240829, 20250722]
             )
             lmp.close()
 

--- a/tests/test_pylammpsmpi_local.py
+++ b/tests/test_pylammpsmpi_local.py
@@ -133,7 +133,7 @@ class TestLocalLammpsLibrary(unittest.TestCase):
 
     def test_create_atoms_typeerror(self):
         with self.assertRaises(TypeError):
-            self.lmp.create_atoms(n=1, id=[1], type=[1], x=None)
+            self.lmp.create_atoms(n=1, atomid=[1], atype=[1], x=None)
 
 
 class TestExecutorLammpsLibrary(unittest.TestCase):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped LAMMPS to a newer release across CI, binder and dev environments; OpenMPI build pin updated and OpenMPI package bumped.
  * Raised required Python baseline from 3.9 to 3.11.

* **Tests**
  * Updated unit tests to accept the new LAMMPS release and adjusted tests to match API renames and error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->