### PR TITLE
[Bug] When the executor is defined it should be used

### DIFF
--- a/src/pylammpsmpi/wrapper/ase.py
+++ b/src/pylammpsmpi/wrapper/ase.py
@@ -56,7 +56,7 @@ class LammpsASELibrary:
         if library is not None:
             self._interactive_library: Any = library
             self._cores = library.cores
-        elif self._cores == 1:
+        elif self._cores == 1 and executor is None:
             lammps = importlib.import_module("lammps").lammps
             self._interactive_library = lammps(
                 cmdargs=cmdargs,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted backend selection so runs that provide an executor now use the expected fallback execution path instead of the direct interactive path.
  * Improved consistency when launching simulations in single-core scenarios with external execution management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->